### PR TITLE
Retry once if Net::HTTPFatalError from S3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,3 @@ language: ruby
 rvm:
 - 2.3.0
 before_install: gem install bundler -v 1.10.6
-env:
-  matrix:
-    secure: HraDnUT1Py2HLDuyYvZaVvgRTFLyfHI9iZA+Zo4auN2IYFdBNAK7x8dNh/LzEjKycUcJ+CGz/8QMegoxcD3bZE5AJtIb0O7u9rw81BQBmNVS4F3Q9PitNQ1Qw/nRBStJTOFcFET9L7wmotS7OZMhWE0fj9OLj6/T4TnL08+1VerWNdFm3uHgJCWNh3iRyNRdb2Je399L5lv9Xopqz1Wk2Xy6oRQAX06W7gEQuEVsGUvslIt+pdYWRv3mrzh+pQDiwdGI7GYWEyVqH6xsdPMnrga/+e6ignoYnGcW9GerojhYo+Gb0O+n6zOwL16/ePils/VjwBt7vZ76H52zNmW2Z5IDfrKB7YTubC3Dsw408r1zLF/b/4ShT0weqkxOtfWYpw02BA87S1aV/yWy+9S6f6kx6fE8nzQWP1h7sUO3xvEdco3OxsFr1qcUoxDU/0zDJk1nLKzFSJ221sRmJYusvt4MMHTt8gCp47R+pKii9J1GsbfFFFJF/nDMfG5fdY9A8LPiY8Zz0lKisEJWz6sWssi53tYavps9n2yZ5QNx0msKakzD/k6TiM/wnZ8Hz6GrJqXhSXG3X+uneeEuINHGnL7lus46+5RY/ae4eu3f/Ci2cDjOTkmlzM2JgJQ5zK/zwKd6ZuKUrcCOp65KZ1vSIek6VmxQYvLEsQAUYBwKDP0=

--- a/spec/star/remote_file_spec.rb
+++ b/spec/star/remote_file_spec.rb
@@ -4,16 +4,17 @@ require 'open-uri'
 
 describe Star::File do
   before { @original_content = "test this file" }
+  before do
+    Star.configuration.access_key_id      = ENV['STAR_TEST_AWS_ACCESS_KEY_ID']
+    Star.configuration.secret_access_key  = ENV['STAR_TEST_SECRET_ACCESS_KEY']
+    Star.configuration.bucket             = ENV['STAR_TEST_BUCKET']
+    Star.configuration.location           = ENV['STAR_TEST_LOCATION']
+    Star.configuration.duration           = 2
+    Star.configuration.remote             = true
+  end
 
   context 'given a remote file' do
     before do
-      Star.configuration.access_key_id      = ENV['STAR_TEST_AWS_ACCESS_KEY_ID']
-      Star.configuration.secret_access_key  = ENV['STAR_TEST_SECRET_ACCESS_KEY']
-      Star.configuration.bucket             = ENV['STAR_TEST_BUCKET']
-      Star.configuration.location           = ENV['STAR_TEST_LOCATION']
-      Star.configuration.duration           = 2
-      Star.configuration.remote             = true
-
       @file = Star::File.new
       @file.open{|f| f.write @original_content}
     end
@@ -45,6 +46,33 @@ describe Star::File do
         @target.copy_from @file
         expect{open @target.url}.not_to raise_error
         expect(open(@target.url).read).to eq @original_content
+      end
+    end
+  end
+
+  context 'given a new file' do
+    subject(:file) { Star::File.new }
+    subject(:store) { file.open{|f| f << "some text to store in a remote file"} }
+
+    context 'given AWS is temporarily unavailable' do
+      let(:http_error) { Net::HTTPFatalError.new(nil, nil) }
+      before { expect(Net::HTTP).to receive(:start).once.and_raise http_error }
+
+      context 'every time' do
+        before { expect(Net::HTTP).to receive(:start).at_least(:once).and_raise http_error }
+
+        it 'raises Net::HTTPFatalError' do
+          expect{ store }.to raise_error Net::HTTPFatalError
+        end
+      end
+
+      context 'only once' do
+        before { expect(Net::HTTP).to receive(:start).at_least(:once).and_return retry_response }
+        let(:retry_response) { Net::HTTPOK.new nil, nil, nil }
+
+        it 'works' do
+          expect{ store }.not_to raise_error
+        end
       end
     end
   end

--- a/spec/star/remote_file_spec.rb
+++ b/spec/star/remote_file_spec.rb
@@ -33,7 +33,7 @@ describe Star::File do
         @url = @file.url
         expect{open @url}.not_to raise_error
         @file.delete
-        expect{open @url}.to raise_error OpenURI::HTTPError, '404 Not Found'
+        expect{open @url}.to raise_error OpenURI::HTTPError
         expect{@file.delete}.not_to raise_error
       end
     end


### PR DESCRIPTION
Sometimes Amazon S3 returns 500 error, but we can simply retry and
solve this problem.